### PR TITLE
#2495: Alowed computed twig as cpr-element in handler

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ about writing changes to this log.
 
 ## [Unreleased]
 
+## [1.2.0] 2024-09-18
+
+* Allowed `webform_computed_twig` as CPR-element in handler.
+
 ## [1.1.1] 2024-09-03
 
 * Correctly determine value of configured CPR element.

--- a/src/Plugin/WebformHandler/FasitWebformHandler.php
+++ b/src/Plugin/WebformHandler/FasitWebformHandler.php
@@ -112,7 +112,12 @@ class FasitWebformHandler extends WebformHandlerBase {
     $form[self::FASIT_HANDLER_GENERAL][self::FASIT_HANDLER_CPR_ELEMENT] = [
       '#type' => 'select',
       '#title' => $this->t('CPR element'),
-      '#options' => $this->getAvailableElementsByType(['textfield', 'os2forms_nemid_cpr', 'os2forms_person_lookup'], $elements),
+      '#options' => $this->getAvailableElementsByType([
+        'textfield',
+        'os2forms_nemid_cpr',
+        'os2forms_person_lookup',
+        'webform_computed_twig',
+      ], $elements),
       '#default_value' => $this->configuration[self::FASIT_HANDLER_GENERAL][self::FASIT_HANDLER_CPR_ELEMENT] ?? '',
       '#description' => $this->t('Choose element containing CPR.'),
       '#required' => TRUE,


### PR DESCRIPTION
#### Link to ticket

https://leantime.itkdev.dk/tickets/showKanban#/tickets/showTicket/2495

#### Description

Allowed `webform_computed_twig` as CPR-element in handler.

