### PR TITLE
Prepare for os2forms 3.16

### DIFF
--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -23,7 +23,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        php-versions: [ '8.2' ]
+        php-versions: [ '8.3' ]
         dependency-version: [ prefer-lowest, prefer-stable ]
     steps:
       - uses: actions/checkout@master
@@ -71,7 +71,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        php-versions: [ '8.2' ]
+        php-versions: [ '8.3' ]
         dependency-version: [ prefer-lowest, prefer-stable ]
     steps:
       - uses: actions/checkout@master
@@ -104,7 +104,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        php-versions: [ '8.2' ]
+        php-versions: [ '8.3' ]
         dependency-version: [ prefer-lowest, prefer-stable ]
     steps:
       - uses: actions/checkout@master

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -23,7 +23,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        php-versions: [ '8.1' ]
+        php-versions: [ '8.2' ]
         dependency-version: [ prefer-lowest, prefer-stable ]
     steps:
       - uses: actions/checkout@master
@@ -71,7 +71,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        php-versions: [ '8.1' ]
+        php-versions: [ '8.2' ]
         dependency-version: [ prefer-lowest, prefer-stable ]
     steps:
       - uses: actions/checkout@master
@@ -104,7 +104,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        php-versions: [ '8.1' ]
+        php-versions: [ '8.2' ]
         dependency-version: [ prefer-lowest, prefer-stable ]
     steps:
       - uses: actions/checkout@master
@@ -129,26 +129,31 @@ jobs:
         run: |
           # We need a Drupal project to run drupal-check (cf. https://github.com/mglaman/drupal-check#usage)
           # Install Drupal
-          composer --no-interaction create-project drupal/recommended-project:^9 --stability=dev drupal
+          composer --no-interaction create-project drupal/recommended-project:^10 drupal
           # Copy our module source code into the Drupal module folder.
           mkdir -p drupal/web/modules/contrib/os2forms_fasit
           cp -r os2forms_fasit.* composer.json src drupal/web/modules/contrib/os2forms_fasit
-          # Add our module as a composer repository.
-          composer --no-interaction --working-dir=drupal config repositories.os2forms/os2forms_fasit path web/modules/contrib/os2forms_fasit
-          # Restore Drupal composer repository.
-          composer --no-interaction --working-dir=drupal config repositories.drupal composer https://packages.drupal.org/8
 
-          composer --no-interaction --working-dir=drupal config --no-plugins allow-plugins.cweagans/composer-patches true
-          composer --no-interaction --working-dir=drupal config --no-plugins allow-plugins.zaporylie/composer-drupal-optimizations true
-          composer --no-interaction --working-dir=drupal config --no-plugins allow-plugins.simplesamlphp/composer-module-installer true
-          # @see https://getcomposer.org/doc/03-cli.md#modifying-extra-values
-          composer --no-interaction --working-dir=drupal config --no-plugins --json extra.enable-patching true
+          composer --working-dir=drupal --no-interaction config minimum-stability dev
+
+          # Allow all plugins
+          composer --working-dir=drupal config --no-plugins allow-plugins true
+
+          # Add our module as a composer repository.
+          composer --working-dir=drupal --no-interaction config --append repositories.os2forms/os2forms_fasit path web/modules/contrib/os2forms_fasit
+          # Restore Drupal composer repository.
+          # composer --working-dir=drupal --no-interaction config --append repositories.drupal composer https://packages.drupal.org/8
+
+          # Make Drupal 10 compatible
+          composer --working-dir=drupal --no-interaction require psr/http-message:^1.0
+          composer --working-dir=drupal --no-interaction require 'mglaman/composer-drupal-lenient'
+          composer --working-dir=drupal config --no-plugins --merge --json extra.drupal-lenient.allowed-list '["drupal/coc_forms_auto_export", "drupal/webform_node_element"]'
 
           # Require our module.
-          composer --no-interaction --working-dir=drupal require 'os2forms/os2forms_fasit:*'
+          composer --working-dir=drupal --no-interaction require 'os2forms/os2forms_fasit:*'
 
           # Check code
-          composer --no-interaction --working-dir=drupal require --dev drupal/core-dev
+          composer --working-dir=drupal --no-interaction require --dev drupal/core-dev
           cd drupal/web/modules/contrib/os2forms_fasit
           # Remove our non-dev dependencies to prevent duplicated Drupal installation
           # PHP Fatal error:  Cannot redeclare drupal_get_filename() (previously declared in /home/runner/work/os2forms_fasit/os2forms_fasit/drupal/web/modules/contrib/os2forms_fasit/vendor/drupal/core/includes/bootstrap.inc:190) in /home/runner/work/os2forms_fasit/os2forms_fasit/drupal/web/core/includes/bootstrap.inc on line 190

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ about writing changes to this log.
 
 ## [Unreleased]
 
+## [1.2.0] 2024-09-24
+
+* Upgrade `os2forms/os2forms` requirement.
+
 ## [1.1.1] 2024-09-03
 
 * Correctly determine value of configured CPR element.

--- a/README.md
+++ b/README.md
@@ -68,8 +68,8 @@ Check coding standards:
 
 ```sh
 // PHP CS Fixer
-docker run --rm --interactive --tty --volume ${PWD}:/app itkdev/php8.1-fpm:latest composer install
-docker run --rm --interactive --tty --volume ${PWD}:/app itkdev/php8.1-fpm:latest composer coding-standards-check
+docker run --rm --interactive --tty --volume ${PWD}:/app itkdev/php8.2-fpm:latest composer install
+docker run --rm --interactive --tty --volume ${PWD}:/app itkdev/php8.2-fpm:latest composer coding-standards-check
 
 // Markdownlint
 docker run --rm --interactive --tty --volume ${PWD}:/app node:20 yarn --cwd /app install
@@ -79,6 +79,6 @@ docker run --rm --interactive --tty --volume ${PWD}:/app node:20 yarn --cwd /app
 Apply coding standards:
 
 ```shell
-docker run --rm --interactive --tty --volume ${PWD}:/app itkdev/php8.1-fpm:latest composer coding-standards-apply
+docker run --rm --interactive --tty --volume ${PWD}:/app itkdev/php8.2-fpm:latest composer coding-standards-apply
 docker run --rm --interactive --tty --volume ${PWD}:/app node:20 yarn --cwd /app coding-standards-apply
 ```

--- a/README.md
+++ b/README.md
@@ -68,8 +68,8 @@ Check coding standards:
 
 ```sh
 // PHP CS Fixer
-docker run --rm --interactive --tty --volume ${PWD}:/app itkdev/php8.2-fpm:latest composer install
-docker run --rm --interactive --tty --volume ${PWD}:/app itkdev/php8.2-fpm:latest composer coding-standards-check
+docker run --rm --interactive --tty --volume ${PWD}:/app itkdev/php8.3-fpm:latest composer install
+docker run --rm --interactive --tty --volume ${PWD}:/app itkdev/php8.3-fpm:latest composer coding-standards-check
 
 // Markdownlint
 docker run --rm --interactive --tty --volume ${PWD}:/app node:20 yarn --cwd /app install
@@ -79,6 +79,6 @@ docker run --rm --interactive --tty --volume ${PWD}:/app node:20 yarn --cwd /app
 Apply coding standards:
 
 ```shell
-docker run --rm --interactive --tty --volume ${PWD}:/app itkdev/php8.2-fpm:latest composer coding-standards-apply
+docker run --rm --interactive --tty --volume ${PWD}:/app itkdev/php8.3-fpm:latest composer coding-standards-apply
 docker run --rm --interactive --tty --volume ${PWD}:/app node:20 yarn --cwd /app coding-standards-apply
 ```

--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,7 @@
         }
     ],
     "require": {
-        "php": "^8.1",
+        "php": "^8.3",
         "ext-dom": "*",
         "drupal/advancedqueue": "^1.0",
         "drupal/webform": "^6.1",

--- a/composer.json
+++ b/composer.json
@@ -55,7 +55,8 @@
             "dealerdirect/phpcodesniffer-composer-installer": true,
             "zaporylie/composer-drupal-optimizations": true,
             "cweagans/composer-patches": true,
-            "simplesamlphp/composer-module-installer": true
+            "simplesamlphp/composer-module-installer": true,
+            "mglaman/composer-drupal-lenient": true
         }
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -22,7 +22,7 @@
         "ext-dom": "*",
         "drupal/advancedqueue": "^1.0",
         "drupal/webform": "^6.1",
-        "os2forms/os2forms": "^3.13",
+        "os2forms/os2forms": "^3.16",
         "symfony/options-resolver": "^5.4 || ^6.0"
     },
     "require-dev": {

--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -10,7 +10,7 @@
   <arg value="p"/>
 
   <arg name="extensions" value="php,module,inc,install,test,profile,theme,css,info,txt,yml"/>
-  <config name="drupal_core_version" value="9"/>
+  <config name="drupal_core_version" value="10"/>
 
   <rule ref="Drupal">
     <!-- <exclude name="Drupal.Files.TxtFileLineLength.TooLong"/> -->

--- a/src/Helper/CertificateLocatorHelper.php
+++ b/src/Helper/CertificateLocatorHelper.php
@@ -4,7 +4,7 @@ namespace Drupal\os2forms_fasit\Helper;
 
 use Drupal\os2forms_fasit\Exception\CertificateLocatorException;
 use GuzzleHttp\Client;
-use Http\Adapter\Guzzle6\Client as GuzzleAdapter;
+use Http\Adapter\Guzzle7\Client as GuzzleAdapter;
 use Http\Factory\Guzzle\RequestFactory;
 use ItkDev\AzureKeyVault\Authorisation\VaultToken;
 use ItkDev\AzureKeyVault\KeyVault\VaultSecret;

--- a/src/Plugin/AdvancedQueue/JobType/Fasit.php
+++ b/src/Plugin/AdvancedQueue/JobType/Fasit.php
@@ -2,12 +2,12 @@
 
 namespace Drupal\os2forms_fasit\Plugin\AdvancedQueue\JobType;
 
-use Drupal\advancedqueue\Job;
-use Drupal\advancedqueue\JobResult;
-use Drupal\advancedqueue\Plugin\AdvancedQueue\JobType\JobTypeBase;
 use Drupal\Core\Logger\LoggerChannelFactoryInterface;
 use Drupal\Core\Logger\LoggerChannelInterface;
 use Drupal\Core\Plugin\ContainerFactoryPluginInterface;
+use Drupal\advancedqueue\Job;
+use Drupal\advancedqueue\JobResult;
+use Drupal\advancedqueue\Plugin\AdvancedQueue\JobType\JobTypeBase;
 use Drupal\os2forms_fasit\Helper\FasitHelper;
 use Drupal\webform\Entity\WebformSubmission;
 use Symfony\Component\DependencyInjection\ContainerInterface;

--- a/src/Plugin/WebformHandler/FasitWebformHandler.php
+++ b/src/Plugin/WebformHandler/FasitWebformHandler.php
@@ -2,13 +2,13 @@
 
 namespace Drupal\os2forms_fasit\Plugin\WebformHandler;
 
-use Drupal\advancedqueue\Job;
 use Drupal\Core\Config\ConfigFactoryInterface;
 use Drupal\Core\Entity\EntityTypeManagerInterface;
 use Drupal\Core\Form\FormStateInterface;
 use Drupal\Core\Logger\LoggerChannelFactoryInterface;
 use Drupal\Core\Logger\LoggerChannelInterface;
 use Drupal\Core\Render\RendererInterface;
+use Drupal\advancedqueue\Job;
 use Drupal\os2forms_fasit\Plugin\AdvancedQueue\JobType\Fasit;
 use Drupal\webform\Plugin\WebformHandlerBase;
 use Drupal\webform\WebformSubmissionConditionsValidatorInterface;


### PR DESCRIPTION
#### Link to ticket

https://leantime.itkdev.dk/tickets/showKanban?search=true&projectId=41&users=21&sprint=all#/tickets/showTicket/2247

#### Description

Upgrades to Drupal 10 via `os2form/os2forms:^3.16` alongside an upgrade to PHP `8.3`

#### Coding standards

The Drupal coder standard is now case sensitive imports.